### PR TITLE
fix git clone failure

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
        {ref,"f78918e7b593fbdc35ec9bcc349aa50f47f45a8b"}},
   0},
  {<<"cache_tab">>,
-  {git,"git@github.com:relaypro-open/cache_tab.git",
+  {git,"https://github.com/relaypro-open/cache_tab.git",
        {ref,"47be88d6f69af6ce555e6615ca409e43def253d1"}},
   0},
  {<<"conv_case">>,{pkg,<<"conv_case">>,<<"0.2.2">>},1},


### PR DESCRIPTION
This fixes a problem causing the dog-in-a-box build to fail for anyone who isn't the owner of relaypro-open/cache_tab :)

```
$ git clone git@github.com:relaypro-open/cache_tab.git
Cloning into 'cache_tab'...
Warning: Permanently added the ECDSA host key for IP address '140.82.114.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```